### PR TITLE
Fix incorrect values passing to JavaScript from configuration

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,30 @@
+name: Run Pytest Suite
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                python-version: ${{ matrix.python-version }}
+
+            - name: Install dependencies
+              run: |
+                pip install .[dev]
+
+            - name: Run Pytest
+              run: pytest test/

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,6 @@ Add the extension in your ``conf.py``:
 .. code-block:: python
 
     extensions = [
-        "sphinxcontrib.jquery",
         "sphinx_datatables",
     ]
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ The following configuration options are available with the following default val
     # in conf.py
 
     # set the version to use for DataTables plugin
-    datatables_version = "1.13.4"
+    datatables_version = "2.3.0"
 
     # name of the class to use for tables to enable DataTables
     datatables_class = "sphinx-datatable"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,6 @@ else:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinxcontrib.jquery",
     # adds .nojekyll to the generated HTML for GitHub
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,7 +143,7 @@ Note that all DataTables will share the same options you set here.
 
 For example, to set the `internationalization plugin <https://datatables.net/plug-ins/i18n/>`__:
 
-.. code-block:: py
+.. code-block:: python
 
     # in conf.py
     datatables_options = {
@@ -151,5 +151,43 @@ For example, to set the `internationalization plugin <https://datatables.net/plu
             "url": "https://cdn.datatables.net/plug-ins/${datatables_version}/i18n/fr-FR.json"
         }
     }
+    # this is equivalent to JavaScript:
+    datatables_options = """\
+    {
+        language: {
+            url: 'https://cdn.datatables.net/plug-ins/${datatables_version}/i18n/fr-FR.json,'
+        },
+    }"""
 
-You can use the special variable `${datatables_version}` to dynamically set the DataTables version in URLs.
+You can use the special variable `${datatables_version}` to dynamically set the DataTables version in URLs (which is substituted by `datatables_version` configuration value from `conf.py`).
+
+.. note:: `datatables_options` to JavaScript object conversion.
+    The dictionary is converted to JSON with `json.dumps <https://docs.python.org/3/library/json.html#json.dumps>`__ and passed to the JavaScript DataTables constructor.
+    If it's a string, it will be passed as is, so it will need to be a valid JavaScript string.
+
+    You can set any options you want, but make sure to follow the DataTables documentation for the correct format.
+    For example, if you want to set the `pageLength` option to `-1` (i.e., show all content), plus rename that option to `Show all`, you would do it like this:
+
+    .. code-block:: python
+
+        # in conf.py
+        # as a dictionary
+        datatables_options = {
+            "pageLength": -1,
+            "language": {"lengthLabels": {"-1": "Show all"}},
+            "lengthMenu": [10, 25, 50, -1],
+        }
+        # as plain JavaScript in a string
+        datatables_options = """\
+            {
+            pageLength: -1,
+            language: {
+                lengthLabels: {
+                    '-1': 'Show all'
+                }
+            },
+            lengthMenu: [10, 25, 50, -1]
+            }
+        """
+
+    Quoting and indentation are optional.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ docs = [
     "sphinx-toolbox",
     "sphinx-copybutton",
 ]
+dev = [
+    "pytest",
+]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
     "sphinx>4",
+    "packaging",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
     "sphinx>4",
-    "sphinxcontrib_jquery>=4.1"
 ]
 
 [tool.setuptools.dynamic]
@@ -44,7 +43,6 @@ Documentation = "https://sharm294.github.io/sphinx-datatables/"
 docs = [
     "sphinx-toolbox",
     "sphinx-copybutton",
-    "sphinxcontrib-jquery",
 ]
 
 [tool.isort]

--- a/src/sphinx_datatables/sphinx_datatables.py
+++ b/src/sphinx_datatables/sphinx_datatables.py
@@ -5,8 +5,11 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
+import json
+from typing import Union
 
 from docutils import nodes
+import packaging.version
 from sphinx.application import Sphinx
 
 INDENT = " " * 4
@@ -20,7 +23,7 @@ class Config:
 
     datatables_version: str
     datatables_class: str
-    datatables_options: dict
+    datatables_options: Union[dict, str]
 
 
 def set_config(app: Sphinx):
@@ -55,49 +58,66 @@ def add_datatables_scripts(
 
     config = get_config(app)
 
-    datatables_js = f"https://cdn.datatables.net/{config.datatables_version}/js/jquery.dataTables.min.js"
-    datatables_css = f"https://cdn.datatables.net/{config.datatables_version}/css/jquery.dataTables.min.css"
+    datetables_version_str = config.datatables_version
+    if packaging.version.parse(datetables_version_str) < packaging.version.parse("2.0.0"):
+        datatables_js = f"https://cdn.datatables.net/{datetables_version_str}/js/jquery.dataTables.min.js"
+        datatables_css = f"https://cdn.datatables.net/{datetables_version_str}/css/jquery.dataTables.min.css"
+    else:
+        datatables_js = f"https://cdn.datatables.net/v/dt/dt-{datetables_version_str}/datatables.min.js"
+        datatables_css = f"https://cdn.datatables.net/v/dt/dt-{datetables_version_str}/datatables.min.css"
 
     app.add_js_file(datatables_js)
     app.add_css_file(datatables_css)
     app.add_js_file("activate_datatables.js")
 
 
-def dict_to_js(options: dict, version: str, indent: str):
+def datatables_options_to_js(options: Union[dict, str], indent: str):
     """
     Convert a Python nested dictionary to a valid JS dictionary object as a string
+    or the string itself if it's not a dict, but indented.
+    Appends a comma at the end if not already present.
     """
-
-    obj = indent + "{\n"
-    for key, value in options.items():
-        if isinstance(value, dict):
-            value_str = dict_to_js(value, version, indent + INDENT)
-        elif isinstance(value, str):
-            value_str = f"'{value},'"
-            value_str = value_str.replace(r"${datatables_version}", version)
-        else:
-            value_str = f"{value},"
-        obj += f"{indent + INDENT}{key}: {value_str}\n"
-    obj += indent + "},\n"
+    if isinstance(options, dict):
+        obj = json.dumps(options, indent=INDENT)
+    else:  # If it's not a dict, just return whatever it is (e.g., a string)
+        obj = options
+    # prepend an indent to each line
+    obj = "\n".join([indent + line for line in obj.splitlines()])
+    if not obj.endswith(","):
+        obj += ","
     return obj
 
 
-def finish(app: Sphinx, exception):
-
+def create_datatables_js(
+    datatables_class: str, datatables_options: Union[dict, str], datatables_version: str
+) -> str:
+    """
+    Create the JS file to activate datatables
+    """
     custom_file = str(
         Path(__file__).parent.joinpath("activate_datatables.js").absolute()
     )
-    config = get_config(app)
     with open(custom_file + ".in", "r") as template:
         contents = template.read()
-        contents = contents.replace(r"${datatables_class}", config.datatables_class)
-        datatables_options = dict_to_js(
-            config.datatables_options, config.datatables_version, INDENT * 2
+        contents = contents.replace(r"${datatables_class}", datatables_class)
+        datatables_options = datatables_options_to_js(datatables_options, INDENT * 2)
+        datatables_options = datatables_options.replace(
+            r"${datatables_version}", datatables_version
         )
         contents = contents.replace(r"${datatables_options}", datatables_options)
-        asset_file = os.path.join(app.builder.outdir, "_static/activate_datatables.js")
-        with open(asset_file, "w+") as f:
-            f.write(contents)
+    return contents
+
+
+def finish(app: Sphinx, exception):
+    config = get_config(app)
+    datatables_config_contents = create_datatables_js(
+        config.datatables_class,
+        config.datatables_options,
+        config.datatables_version,
+    )
+    asset_file = os.path.join(app.builder.outdir, "_static/activate_datatables.js")
+    with open(asset_file, "w+") as f:
+        f.write(datatables_config_contents)
 
 
 def setup(app: Sphinx):
@@ -108,9 +128,9 @@ def setup(app: Sphinx):
         app (Sphinx): Sphinx app
     """
 
-    app.add_config_value("datatables_version", "1.13.4", "html", str)
+    app.add_config_value("datatables_version", "2.3.0", "html", str)
     app.add_config_value("datatables_class", "sphinx-datatable", "html", str)
-    app.add_config_value("datatables_options", {}, "html", dict)
+    app.add_config_value("datatables_options", {}, "html", [dict, str])
 
     app.connect("builder-inited", set_config)
     app.connect("html-page-context", add_datatables_scripts)

--- a/test/test_sphinx_datatables.py
+++ b/test/test_sphinx_datatables.py
@@ -1,0 +1,120 @@
+"""
+Tests suite for sphinx-datatables
+"""
+import pytest
+
+from sphinx_datatables.sphinx_datatables import create_datatables_js
+
+
+@pytest.mark.parametrize(
+    "inputs, expected_outputs",
+    [
+        (
+            ("sphinx-datatable", {"paging": True, "searching": False}, "2.3.0"),
+            """\
+
+// Copyright (c) 2023 Varun Sharma
+//
+// SPDX-License-Identifier: MIT
+
+$(document).ready( function () {
+    $('table.sphinx-datatable').DataTable(
+        {
+            "paging": true,
+            "searching": false
+        },
+    );
+} );
+"""
+        ),
+        (
+            ("sphinx-datatable", {"paging": True, "searching": False}, "3.0.0"),
+            """\
+// Copyright (c) 2023 Varun Sharma
+//
+// SPDX-License-Identifier: MIT
+
+$(document).ready( function () {
+    $('table.sphinx-datatable').DataTable(
+        {
+            "paging": true,
+            "searching": false
+        },
+    );
+} );
+"""
+        ),
+        (
+            ("another-datatable", {}, "3.0.0"),
+            """\
+// Copyright (c) 2023 Varun Sharma
+//
+// SPDX-License-Identifier: MIT
+
+$(document).ready( function () {
+    $('table.another-datatable').DataTable(
+        {},
+    );
+} );
+"""
+        ),
+        (
+            ("sphinx-datatable", {
+    "pageLength": -1,
+    "language": {"lengthLabels": {"-1": "Show all"}},
+    "lengthMenu": [10, 25, 50, -1],
+}, "2.3.0"),
+"""\
+// Copyright (c) 2023 Varun Sharma
+//
+// SPDX-License-Identifier: MIT
+
+$(document).ready( function () {
+    $('table.sphinx-datatable').DataTable(
+        {
+            "pageLength": -1,
+            "language": {
+                "lengthLabels": {
+                    "-1": "Show all"
+                }
+            },
+            "lengthMenu": [
+                10,
+                25,
+                50,
+                -1
+            ]
+        },
+    );
+} );
+"""
+        ),
+        (
+            ("sphinx-datatable", """{
+scrollY: 300,
+paging: false
+}
+""", "2.3.0"),
+            """\
+// Copyright (c) 2023 Varun Sharma
+//
+// SPDX-License-Identifier: MIT
+
+$(document).ready( function () {
+    $('table.sphinx-datatable').DataTable(
+        {
+        scrollY: 300,
+        paging: false
+        },
+    );
+} );"""
+        ),
+    ])
+def test_create_datatables_js(inputs, expected_outputs):
+    """
+    Test the create_datatables_js function
+    """
+    datatables_class, datatables_options, datatables_version = inputs
+    expected_output = expected_outputs.strip()
+    result = create_datatables_js(datatables_class, datatables_options, datatables_version)
+    assert result.strip() == expected_output


### PR DESCRIPTION
Closes #7 , #5 

Adds a bunch of other improvements:
1. Updates CI actions
2. Allows passing a string instead of a dict (just in case)
3. Adds pytest for testing, and some tests (plus CI for that)
4. Removes dependency on `sphinxcontrib-jquery`. DataTables JS remote file already bundles it. Non-jquery bundled version of DataTables could be deemed useful for this project, plus keeping that dependency. Many sphinx extensions out there already depend on it, so it will still be included.
5. Allows using DataTables v2.x.x (links changed at that time, deprecated since 1.10.8 I think, that's the oldest version working with the new scheme)