### PR TITLE
Remove old Python versions from CI

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     continue-on-error: true
 
     steps:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -12,7 +12,7 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,8 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
-    3.14: py314
 
-[testenv:py{39,110,311,312,313,314}]
+[testenv:py{39,110,311,312,313}]
 extras =
     docs
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@ minversion = 4.5.1
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
-[testenv:py{37,38,39,110,311,312}]
+[testenv:py{39,110,311,312,313,314}]
 extras =
     docs
 allowlist_externals =


### PR DESCRIPTION
In Ubuntu 24.04, the current Ubuntu-latest, the minimum Python version is 3.9.