### PR TITLE
Include all test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 include src/sphinx_datatables/*.js.in
+recursive-include test *.py


### PR DESCRIPTION
Congratulations on 1.0.0! :tada: 

This one-liner ensures all the test files end up in the `.tar.gz`; presently, `conftest.py` and `__init__.py` are missing.

This helps downstream packaging, such as https://github.com/conda-forge/staged-recipes/pull/32090

Thanks again for `sphinx-datatables`!